### PR TITLE
Set is_sent to additional_data as False when a new LogEntry is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A module that fixes some issues and provides some reusable tools for Django appl
 - [FAQ](#faq)
 - [Installation](#installation)
 - [Features](#features)
+  - [Signals](#signals)
+    - [`update_log_entry_additional_data_with_is_sent`](#update_log_entry_additional_data_with_is_sent)
   - [Context manager](#context-manager)
     - [`set_request_path`](#set_request_path)
   - [Middleware](#middleware)
@@ -180,8 +182,25 @@ MIDDLEWARE = [
 
 Optionally, you can also use a configuration utility that helps you configure all the models: [How to initialize the Auditlog Configuration helper](#initialization-examples-for-auditlogconfigurationhelper).
 
-
 ## Features
+
+### Signals
+
+Code reference: [signals.py](./auditlog_extra/signals.py).
+
+#### `update_log_entry_additional_data_with_is_sent`
+
+    Sets the `is_sent` key in the `additional_data` dictionary of a new LogEntry
+    instance to False.
+
+    This function is intended to be used as a signal receiver for the `pre_save` signal
+    of the `LogEntry` model. It is designed to modify the `additional_data` field
+    of newly created LogEntry instances before they are saved to the database.
+
+    This is a requirement of https://github.com/City-of-Helsinki/structured-log-transfer.
+    When the structured log transfer tool finishes handling the data,
+    it will then mark the LogEntry as sent (by updating
+    `additional_data["is_sent"]=True`).
 
 ### Context manager
 
@@ -454,22 +473,21 @@ To run the tests using pytest, execute the following command in your terminal:
 pytest
 ```
 
-This will run all the tests in the `tests` directory.  You can specify individual test files or directories using command-line arguments.  For example, to run tests in a specific directory:
+This will run all the tests in the `tests` directory. You can specify individual test files or directories using command-line arguments. For example, to run tests in a specific directory:
 
 ```bash
 pytest tests/test_utils.py
 ```
 
-
 #### tox
 
-Tox is used to manage different testing environments.  It allows you to run your tests in various Python versions and with different dependencies.  The `tox.ini` file defines the different environments.  To run tests using tox, execute:
+Tox is used to manage different testing environments. It allows you to run your tests in various Python versions and with different dependencies. The `tox.ini` file defines the different environments. To run tests using tox, execute:
 
 ```bash
 tox
 ```
 
-This will run the tests defined in the `tox.ini` file.  Each environment will be created and the tests will be run within that environment.  This ensures that your code works correctly across different Python versions and dependency configurations.  You can specify individual environments using command-line arguments.  For example, to run tests in the `py39` environment (Python v3.9):
+This will run the tests defined in the `tox.ini` file. Each environment will be created and the tests will be run within that environment. This ensures that your code works correctly across different Python versions and dependency configurations. You can specify individual environments using command-line arguments. For example, to run tests in the `py39` environment (Python v3.9):
 
 ```bash
 tox -e py39
@@ -479,7 +497,6 @@ For more information on pytest and tox, refer to their respective documentations
 
 - pytest: [https://docs.pytest.org/en/7.4.x/](https://docs.pytest.org/en/7.4.x/)
 - tox: [https://tox.wiki/en/latest/](https://tox.wiki/en/latest/)
-
 
 ## Releases
 
@@ -497,7 +514,7 @@ To build the package, run:
 hatch build
 ```
 
-This will create a distribution package (wheel and sdist) in the `dist` directory.  The wheel package is optimized for faster installation.
+This will create a distribution package (wheel and sdist) in the `dist` directory. The wheel package is optimized for faster installation.
 
 To build only a wheel:
 

--- a/auditlog_extra/apps.py
+++ b/auditlog_extra/apps.py
@@ -5,3 +5,6 @@ from django.utils.translation import gettext_lazy as _
 class AuditLogExtraConfig(AppConfig):
     name = "auditlog_extra"
     verbose_name = _("auditlog extra")
+
+    def ready(self):
+        import auditlog_extra.signals  # noqa

--- a/auditlog_extra/signals.py
+++ b/auditlog_extra/signals.py
@@ -1,0 +1,32 @@
+from auditlog.models import LogEntry
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+
+@receiver(pre_save, sender=LogEntry)
+def update_log_entry_additional_data_with_is_sent(sender, instance, **kwargs):
+    """
+    Sets the `is_sent` key in the `additional_data` dictionary of a new LogEntry
+    instance to False.
+
+    This function is intended to be used as a signal receiver for the `pre_save` signal
+    of the `LogEntry` model. It is designed to modify the `additional_data` field
+    of newly created LogEntry instances before they are saved to the database.
+
+    This is a requirement of https://github.com/City-of-Helsinki/structured-log-transfer.
+    When the structured log transfer tool finishes handling the data,
+    it will then mark the LogEntry as sent (by updating
+    `additional_data["is_sent"]=True`).
+
+    Parameters:
+        sender (LogEntry): The model class of the LogEntry instance being saved.
+        instance (LogEntry): The LogEntry instance being saved.
+        kwargs (dict): Additional keyword arguments passed to the signal handler.
+
+    Returns:
+        None
+    """
+    if not instance.pk:  # Check if the instance is new
+        if not instance.additional_data:
+            instance.additional_data = {}
+        instance.additional_data["is_sent"] = False

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,6 +10,7 @@ INSTALLED_APPS = (
     "django.contrib.staticfiles",
     "django.contrib.admin",
     "auditlog",
+    "auditlog_extra.apps.AuditLogExtraConfig",
     "tests",
 )
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,20 @@
+import pytest
+from auditlog.models import LogEntry
+from auditlog.registry import auditlog
+from django.contrib.auth.models import User
+
+
+@pytest.mark.django_db
+def test_additional_data_is_sent_is_set_to_false_on_log_entry_creation():
+    """Whenever a new LogEntry instance is created (and is preparing to be saved to db),
+    it should have the `additional_data` field populated with `is_sent` boolean (set to False).
+    This is a requirement of https://github.com/City-of-Helsinki/structured-log-transfer.
+    When the structured log transfer tool finishes handling the data,
+    it will then mark the LogEntry as sent (by updating `additional_data["is_sent"]=True`).
+    """
+    # register User model to auditlog registry.
+    auditlog.register(User)
+    # By creating a new User instance, we will also create a LogEntry for it.
+    user = User.objects.create(username="testuser")
+    log_entry = LogEntry.objects.get_for_object(user).first()
+    assert log_entry.additional_data["is_sent"] is False


### PR DESCRIPTION
KK-1413.

Whenever a new LogEntry instance is created (and is preparing to be saved to db), it should have the `additional_data` field populated with `is_sent` boolean (set to False). This is a requirement of https://github.com/City-of-Helsinki/structured-log-transfer. When the structured log transfer tool finishes handling the data, it will then mark the LogEntry as sent (by updating `additional_data["is_sent"]=True`).

Also, the AuditLogExtraConfig was missing from the test application, so it is now added.