### PR TITLE
fix: remove unused and misleading parameters from accessed signal call

### DIFF
--- a/auditlog_extra/graphene_decorators.py
+++ b/auditlog_extra/graphene_decorators.py
@@ -22,7 +22,7 @@ def auditlog_access(cls):
             if node:
                 sender = getattr(cls, "_meta", getattr(cls, "Meta", None)).model
                 if sender:
-                    accessed.send(sender=sender, instance=node, actor=info.context.user)
+                    accessed.send(sender=sender, instance=node)
         except Exception as e:
             logger.exception(f"Could not write access log for node {node}: {e}")
         return node

--- a/auditlog_extra/mixins.py
+++ b/auditlog_extra/mixins.py
@@ -55,7 +55,7 @@ class AuditlogAdminViewAccessLogMixin:
         if self.enable_list_view_audit_logging and request.method == "GET":
             changelist = super().get_changelist_instance(request)
             for obj in changelist.result_list:
-                accessed.send(sender=obj.__class__, instance=obj, actor=request.user)
+                accessed.send(sender=obj.__class__, instance=obj)
         return response
 
     def get_object(self, request, object_id, from_field=None):
@@ -82,7 +82,7 @@ class AuditlogAdminViewAccessLogMixin:
         if obj is not None and not getattr(
             request, self._request_obj_accessed_sent_key
         ):
-            accessed.send(sender=obj.__class__, instance=obj, actor=request.user)
+            accessed.send(sender=obj.__class__, instance=obj)
             # get_object can be called multiple times,
             # so prevent signalling the accessed,
             # if it has already been signalled.

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -24,9 +24,7 @@ def test_auditlog_access_decorator(is_decorated):
 
     if is_decorated:
         # Assert that accessed.send was called with the correct arguments
-        mock_send.assert_called_once_with(
-            sender=DummyTestModel, instance=test_model, actor="testuser"
-        )
+        mock_send.assert_called_once_with(sender=DummyTestModel, instance=test_model)
     else:
         mock_send.assert_not_called()
 


### PR DESCRIPTION
The accessed signal to write access log is called with `accessed.send`. When the signal call was sent, it included an actor keyword argument, which was never read or passed to the actual signal receiver. That makes it misleading and unnecessary. The middleware should set the actor instead.

The `log_access` signal receiver in the `django-auditlog` [never passes the kwargs forward](https://github.com/jazzband/django-auditlog/blob/master/auditlog/receivers.py#L86-L100) and so the LogEntry instance creation does never user the actor-parameter that a accessed signal call might have used.