### PR TITLE
Update Python and Django version support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Continuous integration
 
 env:
-  DEFAULT_PYTHON: 3.10
+  DEFAULT_PYTHON: "3.10"
 
 on:
   push:
@@ -27,10 +27,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Setup Python ${{ inputs.python-version }}
+    - name: Setup Python ${{ env.DEFAULT_PYTHON }}
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ inputs.python-version }}
+        python-version: ${{ env.DEFAULT_PYTHON }}
     - name: Run pre-commit
       uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Continuous integration
 
 env:
-  DEFAULT_PYTHON: 3.9
+  DEFAULT_PYTHON: 3.10
 
 on:
   push:
@@ -41,7 +41,7 @@ jobs:
       TOX_POSARGS: -- --cov=. --cov-report=xml -ra -vv
     strategy:
       matrix:
-        python_version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python_version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,10 +24,10 @@ repos:
       - id: django-upgrade
         args: [--target-version, "4.2"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.8
+    rev: v0.14.2
     hooks:
       # Run the linter.
-      - id: ruff
+      - id: ruff-check
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,24 @@ repos:
       - id: check-yaml
       - id: check-toml
       - id: check-added-large-files
+  # Run pyupgrade and django-upgrade before ruff, as these two might alter
+  # the code in a way that requires reformatting.
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.21.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py310-plus"]
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: "1.29.1"
+    hooks:
+      - id: django-upgrade
+        args: [--target-version, "4.2"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.8
     hooks:
       # Run the linter.
       - id: ruff
+        args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook

--- a/README.md
+++ b/README.md
@@ -487,10 +487,10 @@ Tox is used to manage different testing environments. It allows you to run your 
 tox
 ```
 
-This will run the tests defined in the `tox.ini` file. Each environment will be created and the tests will be run within that environment. This ensures that your code works correctly across different Python versions and dependency configurations. You can specify individual environments using command-line arguments. For example, to run tests in the `py39` environment (Python v3.9):
+This will run the tests defined in the `tox.ini` file. Each environment will be created and the tests will be run within that environment. This ensures that your code works correctly across different Python versions and dependency configurations. You can specify individual environments using command-line arguments. For example, to run tests in the `py310` environment (Python v3.10):
 
 ```bash
-tox -e py39
+tox -e py310
 ```
 
 For more information on pytest and tox, refer to their respective documentations:

--- a/auditlog_extra/context.py
+++ b/auditlog_extra/context.py
@@ -2,7 +2,7 @@ import contextlib
 import time
 from contextvars import ContextVar
 from functools import partial
-from typing import Any, Optional, Type
+from typing import Any
 
 from auditlog.context import auditlog_value
 from auditlog.models import LogEntry
@@ -14,7 +14,7 @@ auditlog_request_context_value = ContextVar("auditlog_value_request")
 
 
 @contextlib.contextmanager
-def set_request_path(request_path: Optional[str] = None):
+def set_request_path(request_path: str | None = None):
     """
     Store the request path in the LogEntry's `additional_data` field.
 
@@ -55,7 +55,7 @@ def set_request_path(request_path: Optional[str] = None):
 
 
 def _set_request_path(
-    sender: Type[LogEntry], instance: LogEntry, signal_duid: Any, **kwargs
+    sender: type[LogEntry], instance: LogEntry, signal_duid: Any, **kwargs
 ):
     """
     Signal receiver to add the request path to LogEntry.additional_data.

--- a/auditlog_extra/services.py
+++ b/auditlog_extra/services.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from auditlog.models import LogEntry
 
 
@@ -8,7 +6,7 @@ class AuditLogContextService:
 
     @staticmethod
     def set_request_path_to_additional_data(
-        log_entry: LogEntry, request_path: Optional[str]
+        log_entry: LogEntry, request_path: str | None
     ):
         """
         Add the request path to the `additional_data` field of a LogEntry.

--- a/auditlog_extra/utils.py
+++ b/auditlog_extra/utils.py
@@ -1,5 +1,3 @@
-from typing import List, Set
-
 from auditlog.registry import auditlog
 from django.apps import apps
 from django.conf import settings
@@ -23,7 +21,7 @@ class AuditLogConfigurationHelper:
     """
 
     @staticmethod
-    def get_app_models() -> List[ModelBase]:
+    def get_app_models() -> list[ModelBase]:
         """
         Fetch all models in your Django project, including those automatically
         created by Django (like those for user accounts or sessions).
@@ -39,7 +37,7 @@ class AuditLogConfigurationHelper:
         return f"{model._meta.app_label}.{model._meta.model_name}"
 
     @staticmethod
-    def get_model_classes(app_model: str) -> List[ModelBase]:
+    def get_model_classes(app_model: str) -> list[ModelBase]:
         return auditlog._get_model_classes(app_model)
 
     @classmethod
@@ -50,17 +48,17 @@ class AuditLogConfigurationHelper:
 
     @classmethod
     def get_excluded_by_default(cls):
-        return set(
+        return {
             cls.get_model_classes(app_model)[0]
             for app_model in auditlog.DEFAULT_EXCLUDE_MODELS
-        )
+        }
 
     @classmethod
-    def get_excluded_models(cls) -> Set[ModelBase]:
+    def get_excluded_models(cls) -> set[ModelBase]:
         """
         Returns a set of models that are explicitly excluded from audit logging.
         """
-        excluded_models: Set[ModelBase] = set()
+        excluded_models: set[ModelBase] = set()
         if (
             hasattr(settings, "AUDITLOG_INCLUDE_ALL_MODELS")
             and settings.AUDITLOG_INCLUDE_ALL_MODELS
@@ -74,7 +72,7 @@ class AuditLogConfigurationHelper:
         return excluded_models | cls.get_excluded_by_default()
 
     @classmethod
-    def get_included_models(cls) -> Set[ModelBase]:
+    def get_included_models(cls) -> set[ModelBase]:
         """Returns a set of models in included mapping for audit logging."""
         included_models = []
         models = getattr(settings, "AUDITLOG_INCLUDE_TRACKING_MODELS", [])
@@ -88,7 +86,7 @@ class AuditLogConfigurationHelper:
         return set(included_models)
 
     @classmethod
-    def get_unconfigured_models(cls) -> Set[ModelBase]:
+    def get_unconfigured_models(cls) -> set[ModelBase]:
         """
         Returns a set of models that are neither registered nor excluded
         from audit logging.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = [{ name = "City of Helsinki", email = "dev@hel.fi" }]
 description = "A module that fixes some issues and provides some reusable tools for Django application using `django-auditlog` in the context of City of Helsinki."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = [
     "django",
     "auditlog",
@@ -17,17 +17,19 @@ classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]
@@ -53,7 +55,7 @@ include = ["auditlog_extra/*.py"]
 packages = ["auditlog_extra"]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=City-of-Helsinki_django-auditlog-extra
 sonar.organization=city-of-helsinki
-sonar.python.version=3.9
+sonar.python.version=3.10
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.test.inclusions=**/tests/**/*
 sonar.exclusions=**/tests/**/*,**/migrations/*,commitlint.config.js

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,4 +1,3 @@
-from typing import List, Optional
 from unittest import mock
 
 import pytest
@@ -60,7 +59,7 @@ def factory():
 def model_admin(all_objects):
     (obj1, obj2) = all_objects
 
-    def get_model_admin(result_list: Optional[List] = None, **kwargs):
+    def get_model_admin(result_list: list | None = None, **kwargs):
         class MockedChangeList(ChangeList):
             show_full_result_count = False
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,10 +35,10 @@ def test_get_excluded_models(excluded_model_apps, settings):
     excluded_models = AuditLogConfigurationHelper.get_excluded_models()
     assert (
         excluded_models - AuditLogConfigurationHelper.get_excluded_by_default()
-    ) == set(
+    ) == {
         AuditLogConfigurationHelper.get_model_classes(model_app)[0]
         for model_app in excluded_model_apps
-    )
+    }
 
 
 @pytest.mark.parametrize(
@@ -54,10 +54,10 @@ def test_get_included_models(included_model_apps, settings):
     settings.AUDITLOG_INCLUDE_ALL_MODELS = True
     settings.AUDITLOG_INCLUDE_TRACKING_MODELS = included_model_apps
     included_models = AuditLogConfigurationHelper.get_included_models()
-    assert included_models == set(
+    assert included_models == {
         AuditLogConfigurationHelper.get_model_classes(model_app)[0]
         for model_app in included_model_apps
-    )
+    }
 
 
 def test_get_unconfigured_models(settings):

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
-    py39-django{42}
-    py310-django{42,50,51,main}
-    py311-django{42,50,51,main}
-    py312-django{42,50,51,main}
-    py313-django{51,main}
+    py310-django{42,51,52,main}
+    py311-django{42,51,52,main}
+    py312-django{42,51,52,main}
+    py313-django{51,52,main}
+    py314-django{52,main}
 
 [testenv]
 description = run unit tests
@@ -14,8 +14,8 @@ setenv =
     PYTHONWARNINGS=once
 deps =
     django42: Django>=4.2,<5.0
-    django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<6.0
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 extras = test
@@ -30,4 +30,7 @@ ignore_outcome = true
 ignore_outcome = true
 
 [testenv:py313-djangomain]
+ignore_outcome = true
+
+[testenv:py314-djangomain]
 ignore_outcome = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py310-django{42,51,52,main}
-    py311-django{42,51,52,main}
+    py310-django{42,51,52}
+    py311-django{42,51,52}
     py312-django{42,51,52,main}
     py313-django{51,52,main}
     py314-django{52,main}
@@ -19,12 +19,6 @@ deps =
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 extras = test
-
-[testenv:py310-djangomain]
-ignore_outcome = true
-
-[testenv:py311-djangomain]
-ignore_outcome = true
 
 [testenv:py312-djangomain]
 ignore_outcome = true


### PR DESCRIPTION
- Drop Python 3.9 support
- Add Python 3.14 support
- Drop Django 5.0 support
- Add Django 5.2 support
- Add pyupgrade pre-commit hook
- Add django-upgrade pre-commit hook
- Fix broken references in ci.yml

Refs: RATY-253