### PR TITLE
ci: unify sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,4 +3,4 @@ sonar.organization=city-of-helsinki
 sonar.python.version=3.10
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.test.inclusions=**/tests/**/*
-sonar.exclusions=**/tests/**/*,**/migrations/*,commitlint.config.js
+sonar.exclusions=**/migrations/*,pipelines/**/*


### PR DESCRIPTION
Unify `sonar-project.properties` format across City-of-Helsinki Python repos.

Changes:
- Remove `**/tests/**/*` and `commitlint.config.js` from `sonar.exclusions`
- Add `pipelines/**/*` to `sonar.exclusions`

Refs: KEH-189